### PR TITLE
Removed mouse callbacks. Placed after a check of obs_wav1

### DIFF
--- a/src/hubbleds/stages/stage_one.py
+++ b/src/hubbleds/stages/stage_one.py
@@ -332,6 +332,10 @@ class StageOne(HubbleStage):
         if advancing and new == "res_wav1":
             spectrum_viewer = self.get_viewer("spectrum_viewer")
             spectrum_viewer.toolbar.set_tool_enabled("hubble:restwave", True)
+        if advancing and new == "obs_wav1":
+            spectrum_viewer = self.get_viewer("spectrum_viewer")
+            spectrum_viewer.add_event_callback(spectrum_viewer._on_mouse_moved, events=['mousemove'])
+            spectrum_viewer.add_event_callback(spectrum_viewer._on_click, events=['click'])
         if advancing and new == "obs_wav2":
             spectrum_viewer = self.get_viewer("spectrum_viewer")
             spectrum_viewer.toolbar.set_tool_enabled("hubble:wavezoom", True)

--- a/src/hubbleds/viewers/spectrum_view.py
+++ b/src/hubbleds/viewers/spectrum_view.py
@@ -170,8 +170,6 @@ class SpecView(BqplotScatterView):
                               self.user_line_label,
                               self.element_tick, self.element_label]
 
-        self.add_event_callback(self._on_mouse_moved, events=['mousemove'])
-        self.add_event_callback(self._on_click, events=['click'])
         self.scale_y.observe(self._update_locations, names=['min', 'max'])
 
         add_callback(self.state, 'y_min', self._on_ymin_change, echo_old=True)


### PR DESCRIPTION
Removed mouse callbacks from SpecView class and placed them into StageOne._on_marker_update. This way those callback are only active when we want them.